### PR TITLE
resolved camelot-py dependency conflicts and add system packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    poppler-utils \
+    tesseract-ocr \
     && rm -rf /var/lib/apt/lists/*
 
 # Install dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ uvicorn[standard]==0.27.0
 
 # PDF Processing
 pdfplumber==0.10.3
-camelot-py[cv]==0.11.0
+camelot-py==0.11.0
 pytesseract==0.3.10
 PyMuPDF==1.24.2
 
@@ -24,4 +24,3 @@ flake8==7.0.0
 
 # Additional Dependencies for Camelot
 opencv-python==4.9.0.80
-ghostscript==0.7


### PR DESCRIPTION
## Description
Fix Docker build failures caused by unresolvable camelot-py dependencies and missing system packages required for PDF/OCR processing.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Infrastructure/DevOps change

## Related Issues
Closes #21 

## Changes Made
- Changed `camelot-py[cv]` to `camelot-py` in requirements.txt (removed `[cv]` extra that requires unavailable `pdftopng>=0.2.3`)
- Added system dependencies to Dockerfile: `poppler-utils` and `tesseract-ocr`
- Removed unused `ghostscript==0.7` dependency

## Testing
- [x] Docker build succeeds: `docker compose build`
- [x] API starts successfully: `docker compose up -d api`
- [x] API responds to requests: `curl http://localhost:8000/docs`

Checklist
- [x] Docker image builds without errors
- [x] API container starts successfully
- [x] API responds on `http://localhost:8000`
- [x] No unused dependencies remain
- [x] System dependencies properly documented